### PR TITLE
Added requirement for nodegit to run on Ubuntu 14

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,7 +13,7 @@ apt-get update && apt-get install -y libssl0.9.8 libsqlite-dev \
   libjpeg8-dev libpango1.0-dev libgif-dev libxml2-dev \
   libmagickcore-dev libmagickwand-dev build-essential libkrb5-dev python-dev \
   libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev llvm \
-  ghostscript
+  ghostscript libstdc++-4.9-dev
 
   # Install ImageMagick
   export MAKEFLAGS="-j $(grep -c ^processor /proc/cpuinfo)"


### PR DESCRIPTION
https://github.com/nodegit/nodegit/issues/853
https://github.com/fbaumgardt/perseus-proofreader/issues/3

Please test. I worked with support from Xervo.io to find the solution, but I don't have an environment to test.